### PR TITLE
Conf parsing

### DIFF
--- a/classes/Config.cpp
+++ b/classes/Config.cpp
@@ -423,9 +423,9 @@ void Config::parse_server(std::fstream &file, std::string &word)
     }
 
     if (serv.names_empty()) // add empty name if no name has been provided
-        serv.add_name("");
+        serv.add_name(DEFAULT_SERV_NAME);
     if (serv.listen_empty())
-        serv.add_listen(std::make_pair("*", 80));
+        serv.add_listen(DEFAULT_LISTEN);
     _servers.push_back(serv);
 }
 

--- a/classes/Config.cpp
+++ b/classes/Config.cpp
@@ -317,7 +317,7 @@ bool Config::parse_common_directive(std::fstream &file, args_t &args, Context_t 
     else if (args[0] == "allow_method")
         parse_allow_method(args, context, file);
     else if (args[0] == "set_cgi")
-        parse_allow_method(args, context, file);
+        parse_set_cgi(args, context, file);
     else
         return false;
     return true;

--- a/classes/Config.cpp
+++ b/classes/Config.cpp
@@ -82,7 +82,7 @@ long Config::ft_atoi(const char *str) const
 void Config::parse_location(args_t &args, Context_t &context, std::fstream &file, std::string &word)
 {
     if (args.size() != 2)
-        throw_close(CONF_ERR_LOC_NARG, file);
+        throw_close_narg("location", file);
     Location_t loc(args[1]);
 
     if (dynamic_cast<Location_t*>(&context))
@@ -116,7 +116,7 @@ void Config::parse_location(args_t &args, Context_t &context, std::fstream &file
 
 void Config::parse_root(args_t &args, Context_t &context, std::fstream &file){
     if (args.size() != 2)
-        throw_close(CONF_ERR_ROOT_NARG, file);
+        throw_close_narg("root", file);
     context.set_root(args[1]);
 }
 
@@ -126,7 +126,7 @@ void Config::parse_root(args_t &args, Context_t &context, std::fstream &file){
 
 void Config::parse_index(args_t &args, Context_t &context, std::fstream &file){
     if (args.size() <= 1)
-        throw_close(CONF_ERR_IDX_NARG, file);
+        throw_close_narg("index", file);
     for (args_t::iterator it = ++args.begin(); it != args.end(); ++it)
         context.add_index(*it);
 }
@@ -137,7 +137,7 @@ void Config::parse_index(args_t &args, Context_t &context, std::fstream &file){
 
 void Config::parse_autoindex(args_t &args, Context_t &context, std::fstream &file){
     if (args.size() != 2)
-        throw_close(CONF_ERR_AUTO_IDX_NARG, file);
+        throw_close_narg("autoindex", file);
     if (args[1] == "on")
         context.set_autoindex(true);
     else if (args[1] == "off")
@@ -153,7 +153,7 @@ void Config::parse_autoindex(args_t &args, Context_t &context, std::fstream &fil
 
 void Config::parse_client_max_body_size(args_t &args, Context_t &context, std::fstream &file){
     if (args.size() != 2)
-        throw_close(CONF_ERR_MAXSZ_NARG, file);
+        throw_close_narg("client_max_body_size", file);
     for (std::string::iterator it = args[1].begin(); it != args[1].end(); ++it)
         if (!ft_isdigit(*it))
             throw_close(CONF_ERR_MAXSZ_VARG, file);
@@ -167,7 +167,7 @@ void Config::parse_client_max_body_size(args_t &args, Context_t &context, std::f
 
 void Config::parse_error_page(args_t &args, Context_t &context, std::fstream &file){
     if (args.size() < 3)
-        throw_close(CONF_ERR_ERPAGE_NARG, file);
+        throw_close_narg("error_page", file);
     for (args_t::iterator it = ++args.begin(); it != --args.end(); ++it)
     {
         for (std::string::iterator str_it = it->begin(); str_it != it->end(); ++str_it)
@@ -183,7 +183,7 @@ void Config::parse_error_page(args_t &args, Context_t &context, std::fstream &fi
 
 void Config::parse_allow_method(args_t &args, Context_t &context, std::fstream &file){
     if (args.size() < 2)
-        throw_close(CONF_ERR_METH_NARG, file);
+        throw_close_narg("allow_method", file);
     for (args_t::iterator it = ++args.begin(); it != args.end(); ++it)
     {
         if (*it == "GET")
@@ -203,7 +203,7 @@ void Config::parse_allow_method(args_t &args, Context_t &context, std::fstream &
 
 void Config::parse_set_cgi(args_t &args, Context_t &context, std::fstream &file){
     if (args.size() != 3)
-        throw_close(CONF_ERR_CGI_NARG, file);
+        throw_close_narg("set_cgi", file);
     if (args[2][0] != '.')
         throw_close(CONF_ERR_CGI_WRG_TYPE, file);
     context.set_cgi(args[1], args[2]);
@@ -214,7 +214,7 @@ void Config::parse_set_cgi(args_t &args, Context_t &context, std::fstream &file)
 
 void Config::parse_alias(args_t &args, Location_t &loc, std::fstream &file){
     if (args.size() != 2)
-        throw_close(CONF_ERR_ALIAS_NARG, file);
+        throw_close_narg("alias", file);
     loc.set_alias(args[1]);
 }
 
@@ -257,7 +257,7 @@ void Config::parse_listen(args_t &args, Server_t &server, std::fstream &file){
     in_port_t   port = 80;
 
     if (args.size() != 2)
-        throw_close(CONF_ERR_LIST_NARG, file);
+        throw_close_narg("listen", file);
     if (args[1].find(':') != std::string::npos)
     {
         size_t pos = args[1].find(':');
@@ -497,11 +497,18 @@ Config	&Config::operator=(const Config &other)
 	return *this;
 }
 
+void Config::throw_close_narg(const char *directive, std::fstream &f){
+    f.close();
+    std::stringstream s;
+    s << CONF_ERR_HEAD << "Invalid number of arguments in \"" << directive << "\" directive. At line: " << _last_dir << std::endl;
+    std::cerr << s.str();
+    throw(ParseErrException());
+}
 
 void Config::throw_close(const char *message, std::fstream &f){
     f.close();
     std::stringstream s;
-    s << CONF_ERR_HEAD << "at line " << _last_dir << ": " << message <<std::endl;
+    s << CONF_ERR_HEAD << message << ". At line: " << _last_dir << std::endl;
     std::cerr << s.str();
     throw(ParseErrException());
 }

--- a/classes/Config.cpp
+++ b/classes/Config.cpp
@@ -451,16 +451,21 @@ Config::Config(const char * path): _servers(std::vector<Server_t>()),
                                    _last_dir(1)
 {
     std::fstream file(path, std::ios_base::in);
-    std::string word;
+    std::string  word;
+
     if (file.fail())
         throw (FileOpenException());
-    while (file.good())
+    try
     {
-        next_word(file, word);
-        if (!word.empty()){
-            parse_server(file, word);
+        while (file.good())
+        {
+            next_word(file, word);
+            if (!word.empty()){
+                parse_server(file, word);
+            }
         }
     }
+    catch (const ParseErrException &e) {}
     file.close();
 }
 

--- a/classes/Config.cpp
+++ b/classes/Config.cpp
@@ -197,6 +197,17 @@ void Config::parse_allow_method(args_t &args, Context_t &context, std::fstream &
     }
 }
 
+/*********************\
+|* set_cgi directive *|
+\*********************/
+
+void Config::parse_set_cgi(args_t &args, Context_t &context, std::fstream &file){
+    if (args.size() != 3)
+        throw_close(CONF_ERR_CGI_NARG, file);
+    if (args[2][0] != '.')
+        throw_close(CONF_ERR_CGI_WRG_TYPE, file);
+    context.set_cgi(args[1], args[2]);
+}
 /*************************\
 |* server_name directive *|
 \*************************/
@@ -304,6 +315,8 @@ bool Config::parse_common_directive(std::fstream &file, args_t &args, Context_t 
     else if (args[0] == "error_page")
         parse_error_page(args, context, file);
     else if (args[0] == "allow_method")
+        parse_allow_method(args, context, file);
+    else if (args[0] == "set_cgi")
         parse_allow_method(args, context, file);
     else
         return false;

--- a/classes/Context_t.cpp
+++ b/classes/Context_t.cpp
@@ -114,6 +114,12 @@ void Context_t::allow_delete() {
     _allow_method[METH_DELETE] = true;
 }
 
+void  Context_t::set_cgi(std::string &path, std::string &type) {
+    _is_set[IS_CGI] = true;
+    _cgi.first = path;
+    _cgi.second = type;
+}
+
 // Getters ----------------------------------
 const std::string &Context_t::get_root()
 {
@@ -153,4 +159,14 @@ bool Context_t::is_allowed_post()
 bool Context_t::is_allowed_delete()
 {
     return _allow_method[METH_DELETE];
+}
+
+const std::string &Context_t::get_cgi_path()
+{
+    return _cgi.first;
+}
+
+const std::string &Context_t::get_cgi_type()
+{
+    return _cgi.second;
 }

--- a/classes/Context_t.cpp
+++ b/classes/Context_t.cpp
@@ -2,10 +2,10 @@
 
 Context_t::Context_t():
     _is_set(std::vector<bool>(IS_BOOL_SIZE, false)),
-    _root("./html"),
+    _root(DEFAULT_ROOT),
     _index(std::list<std::string>()),
-    _autoindex(false),
-    _client_max_body_size(1000000),
+    _autoindex(DEFAULT_AUTOINDEX),
+    _client_max_body_size(DEFAULT_MAX_BODY_SIZE ),
     _error_pages(std::map<std::string, std::string>()),
     _allow_method(std::vector<bool>(IS_BOOL_SIZE, false))
 {

--- a/classes/Context_t.cpp
+++ b/classes/Context_t.cpp
@@ -7,7 +7,8 @@ Context_t::Context_t():
     _autoindex(DEFAULT_AUTOINDEX),
     _client_max_body_size(DEFAULT_MAX_BODY_SIZE ),
     _error_pages(std::map<std::string, std::string>()),
-    _allow_method(std::vector<bool>(IS_BOOL_SIZE, false))
+    _allow_method(std::vector<bool>(IS_BOOL_SIZE, false)),
+    _cgi(std::make_pair(DEFAULT_CGI_PATH, DEFAULT_CGI_TYPE))
 {
 }
 
@@ -18,7 +19,8 @@ Context_t::Context_t(const Context_t &copy):
     _autoindex(copy._autoindex),
     _client_max_body_size(copy._client_max_body_size),
     _error_pages(copy._error_pages),
-    _allow_method(copy._allow_method)
+    _allow_method(copy._allow_method),
+    _cgi(copy._cgi)
 {
 }
 
@@ -34,6 +36,7 @@ Context_t	&Context_t::operator=(const Context_t &other)
     _client_max_body_size   = other._client_max_body_size;
     _error_pages            = other._error_pages;
     _allow_method           = other._allow_method;
+    _cgi                    = other._cgi;
 	return *this;
 }
 
@@ -53,6 +56,8 @@ void Context_t::inherit(Context_t &parent) {
         _error_pages = parent._error_pages;
     if (!_is_set[IS_ALLOW_METHOD])
          _allow_method = parent._allow_method;
+    if (!_is_set[IS_CGI])
+         _cgi = parent._cgi;
 }
 
 // Unset directives default values ---------

--- a/classes/Location_t.cpp
+++ b/classes/Location_t.cpp
@@ -67,6 +67,8 @@ void Location_t::print(){
         std::cout << "DELETE ";
     std::cout << "\n";
 
+    std::cout << "    _cgi path/type: " << get_cgi_path() << "/" << get_cgi_type() << '\n';
+
     std::cout << "    index:\n";
     for (std::list<std::string>::iterator it = _index.begin();
             it != _index.end(); ++it)

--- a/classes/Location_t.cpp
+++ b/classes/Location_t.cpp
@@ -3,7 +3,7 @@
 
 Location_t::Location_t(const std::string uri): _uri(uri),
                                                _locations(std::vector<Location_t>()),
-                                               _alias("")
+                                               _alias(DEFAULT_ALIAS)
 {
 }
 

--- a/classes/Location_t.cpp
+++ b/classes/Location_t.cpp
@@ -67,7 +67,8 @@ void Location_t::print(){
         std::cout << "DELETE ";
     std::cout << "\n";
 
-    std::cout << "    _cgi path/type: " << get_cgi_path() << "/" << get_cgi_type() << '\n';
+    std::cout << "    _cgi_path: " << get_cgi_path() << '\n';
+    std::cout << "    _cgi_type: " << get_cgi_type() << '\n';
 
     std::cout << "    index:\n";
     for (std::list<std::string>::iterator it = _index.begin();

--- a/classes/Server_t.cpp
+++ b/classes/Server_t.cpp
@@ -114,7 +114,8 @@ void Server_t::print(){
         std::cout << "DELETE ";
     std::cout << "\n";
 
-    std::cout << "  _cgi path/type: " << get_cgi_path() << "/" << get_cgi_type() << '\n';
+    std::cout << "  _cgi_path: " << get_cgi_path() << '\n';
+    std::cout << "  _cgi_type: " << get_cgi_type() << '\n';
 
 
     if  (_locations.size())

--- a/classes/Server_t.cpp
+++ b/classes/Server_t.cpp
@@ -114,6 +114,7 @@ void Server_t::print(){
         std::cout << "DELETE ";
     std::cout << "\n";
 
+    std::cout << "  _cgi path/type: " << get_cgi_path() << "/" << get_cgi_type() << '\n';
 
 
     if  (_locations.size())

--- a/headers/Config.hpp
+++ b/headers/Config.hpp
@@ -18,33 +18,20 @@
 # define CONF_ERR_UNEX_CBRKT  "unexpected closing bracket }"
 # define CONF_ERR_UNEX_OBRKT  "unexpected opening bracket {"
 
-# define CONF_ERR_LIST_NARG  "wrong number of args on listen directive"
 # define CONF_ERR_LIST_VARG  "wrong argument value on listen directive"
 
 # define CONF_ERR_NONAME  "no argument provided to server_name directive"
 
-# define CONF_ERR_ROOT_NARG  "root directive can only take one argument"
-
-# define CONF_ERR_LOC_NARG  "wrong number of args on location context"
-
-# define CONF_ERR_IDX_NARG  "wrong number of args on index directive"
-
-# define CONF_ERR_AUTO_IDX_NARG  "wrong number of args on autoindex directive"
 # define CONF_ERR_AUTO_IDX_VARG  "wrong arg value on autoindex directive"
 
-# define CONF_ERR_MAXSZ_NARG  "wrong number of args on client_max_body_size directive"
 # define CONF_ERR_MAXSZ_VARG  "wrong arg value on client_max_body_size directive"
 
-# define CONF_ERR_ERPAGE_NARG  "wrong number of args on error_page directive"
 # define CONF_ERR_ERPAGE_VARG  "wrong value of args on error_page directive"
 
-# define CONF_ERR_METH_NARG  "wrong number of args on allow_method directive"
 # define CONF_ERR_METH_VARG  "unrecognized method in allow_method directive"
 
-# define CONF_ERR_CGI_NARG     "wrong number of args on set_cgi directive"
 # define CONF_ERR_CGI_WRG_TYPE "wrong cgi type in set_cgi directive (file types start by a dot: .xxx)"
 
-# define CONF_ERR_ALIAS_NARG  "wrong number of args on alias directive"
 
 # define CONF_ERR_SUBLOCATION  "sublocation is outside of its parent"
 
@@ -101,7 +88,8 @@ class Config
         void check_server(std::fstream &file, std::string &word);
         void parse_server(std::fstream &file, std::string &word);
 
-        // Exception management + file closing
+        // Error management + file closing
+        void throw_close_narg(const char *s, std::fstream &f);
         void throw_close(const char *s, std::fstream &f);
 
         std::vector<Server_t> get_servers();

--- a/headers/Config.hpp
+++ b/headers/Config.hpp
@@ -9,6 +9,8 @@
 # include "Location_t.hpp"
 # include "Context_t.hpp"
 
+# include "default_conf.hpp"
+
 # define CONF_ERR_HEAD "Error in conf: "
 
 # define CONF_ERR_NO_SERV  "expected server{...} directive"

--- a/headers/Config.hpp
+++ b/headers/Config.hpp
@@ -41,6 +41,9 @@
 # define CONF_ERR_METH_NARG  "wrong number of args on allow_method directive"
 # define CONF_ERR_METH_VARG  "unrecognized method in allow_method directive"
 
+# define CONF_ERR_CGI_NARG     "wrong number of args on set_cgi directive"
+# define CONF_ERR_CGI_WRG_TYPE "wrong cgi type in set_cgi directive (file types start by a dot: .xxx)"
+
 # define CONF_ERR_ALIAS_NARG  "wrong number of args on alias directive"
 
 # define CONF_ERR_SUBLOCATION  "sublocation is outside of its parent"
@@ -78,6 +81,7 @@ class Config
         void parse_client_max_body_size(args_t &args, Context_t &context, std::fstream &file);
         void parse_error_page(args_t &args, Context_t &context, std::fstream &file);
         void parse_allow_method(args_t &args, Context_t &context, std::fstream &file);
+        void parse_set_cgi(args_t &args, Context_t &context, std::fstream &file);
 
         // *** Location Directive(s)
         void parse_alias(args_t &args, Location_t &loc, std::fstream &file);

--- a/headers/Context_t.hpp
+++ b/headers/Context_t.hpp
@@ -6,6 +6,8 @@
 # include <string>
 # include <map>
 
+# include "default_conf.hpp"
+
 // is_set bool vector correspondance
 # define IS_BOOL_SIZE     6
 # define IS_ROOT          0

--- a/headers/Context_t.hpp
+++ b/headers/Context_t.hpp
@@ -60,6 +60,8 @@ class Context_t
         void allow_get();
         void allow_post();
         void allow_delete();
+        void set_cgi(std::string &path, std::string &type);
+
         virtual void add_location(const Location_t*) = 0;
 
 // Getters ----------------------------------
@@ -71,6 +73,8 @@ class Context_t
         bool is_allowed_get();
         bool is_allowed_post();
         bool is_allowed_delete();
+        const std::string &get_cgi_path();
+        const std::string &get_cgi_type();
 };
 
 #endif

--- a/headers/Context_t.hpp
+++ b/headers/Context_t.hpp
@@ -9,13 +9,14 @@
 # include "default_conf.hpp"
 
 // is_set bool vector correspondance
-# define IS_BOOL_SIZE     6
+# define IS_BOOL_SIZE     7
 # define IS_ROOT          0
 # define IS_INDEX         1
 # define IS_AUTO_INDEX    2
 # define IS_MAX_BODY_SIZE 3
 # define IS_ERROR_PAGES   4
 # define IS_ALLOW_METHOD  5
+# define IS_CGI           6
 
 // allow_method bool vector correspondance
 # define METH_SIZE   3
@@ -36,6 +37,7 @@ class Context_t
         unsigned long          _client_max_body_size;
         std::map<std::string, std::string> _error_pages;
         std::vector<bool>      _allow_method;
+        std::pair<std::string, std::string> _cgi;
 
     public:
         Context_t();

--- a/headers/Location_t.hpp
+++ b/headers/Location_t.hpp
@@ -7,6 +7,7 @@
 # include <set>
 
 # include "Context_t.hpp"
+# include "default_conf.hpp"
 
 class Location_t : public Context_t
 {

--- a/headers/default_conf.hpp
+++ b/headers/default_conf.hpp
@@ -1,0 +1,16 @@
+#ifndef DEFAULT_CONF_HPP
+# define DEFAULT_CONF_HPP
+
+// Server directives
+# define DEFAULT_SERV_NAME ""
+# define DEFAULT_LISTEN std::make_pair("*",80)
+
+// Location directives
+# define DEFAULT_ALIAS ""
+
+// Common directives
+# define DEFAULT_ROOT "./html"
+# define DEFAULT_AUTOINDEX false
+# define DEFAULT_MAX_BODY_SIZE 1000000
+
+#endif

--- a/headers/default_conf.hpp
+++ b/headers/default_conf.hpp
@@ -3,6 +3,7 @@
 
 // Server directives
 # define DEFAULT_SERV_NAME ""
+
 # define DEFAULT_LISTEN std::make_pair("*",80)
 
 // Location directives
@@ -10,7 +11,12 @@
 
 // Common directives
 # define DEFAULT_ROOT "./html"
+
 # define DEFAULT_AUTOINDEX false
+
 # define DEFAULT_MAX_BODY_SIZE 1000000
+
+# define DEFAULT_CGI_PATH "./bin/php-cgi"
+# define DEFAULT_CGI_TYPE ".php"
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -35,7 +35,7 @@ int main(int ac, char **av) {
             Listener listener;
             listener.execute();
             Poller		poller(listener);
-            while (true)
+            while (false)
             {
                 poller.start();
                 poller.handle();

--- a/tests/default.conf
+++ b/tests/default.conf
@@ -16,10 +16,13 @@ server{
     error_page 401 402 403 40x.html;
     server_name     localhost ; #ui #iciaussi
     server_name     super non ? ; #ui #iciaussi
+
+    set_cgi  ./autre_binaire  .autre_extension;
         
 #    ui#etuncom
 #    non; #encoreun
     location panam{
+        set_cgi  ./encore_autre_binaire  .encore_autre_extension;
         error_page 402 402.html;
     }
 
@@ -32,6 +35,7 @@ server{
     index fabrice;
     autoindex on;
     client_max_body_size 9999;
+    set_cgi  ./super_binaire  .super;
     location /ici {
         autoindex off;
         index hubert;

--- a/tests/failing_confs/auto_index_narg.conf
+++ b/tests/failing_confs/auto_index_narg.conf
@@ -1,3 +1,3 @@
 server{
-    auto_index;
+    autoindex;
 }

--- a/tests/failing_confs/auto_index_varg.conf
+++ b/tests/failing_confs/auto_index_varg.conf
@@ -1,3 +1,3 @@
 server{
-    auto_index oui;
+    autoindex oui;
 }

--- a/tests/failing_confs/test.sh
+++ b/tests/failing_confs/test.sh
@@ -1,3 +1,4 @@
+make -C ../..
 for f in *.conf
 do
     echo "Processing $f"


### PR DESCRIPTION
### Nouvelle directive commune à Server et Location
- **Set_cgi**
`set_cgi [path] [type]`
Stocké dans une paire de string. Le type désigne l'extension des fichiers qui seront traités par cgi. Cette extension doit commencer par un point. 
Valeur si directive absente: path: `./bin/php-cgi` type: `.php`

### Autres changements mineurs
- Les valeurs par défauts des directives sont désormais centralisées dans un header additionnel: `default_conf.hpp`
- Quelques modifications de la gestion des erreurs, désormais plus fidèle à nginx et moins de define.
