### PR TITLE
set relative path as translated path for easy use (TEMPORARY)

### DIFF
--- a/classes/Cgi.cpp
+++ b/classes/Cgi.cpp
@@ -5,7 +5,7 @@ const char* Cgi::MallocFailedException::what() const throw() {
 }
 
 
-Cgi::Cgi(char *path, Request &request) : _cgi_path(path), _status_code() {
+Cgi::Cgi(char *path, std::string t_path, Request &request) : _cgi_path(path), _translated_path(t_path), _status_code() {
 	std::vector<char> vbody = request.getBody();
 	_body_size = vbody.size();
 	if (!(_body = static_cast<char *>(malloc(sizeof(char) * (_body_size + 1))))) {
@@ -103,7 +103,7 @@ void Cgi::setCgiEnv(Request &request) {
 
 	mapped_cgi_env["REQUEST_METHOD"] = request.getMethod();
 	mapped_cgi_env["PATH_INFO"] = request.getPath();
-	mapped_cgi_env["PATH_TRANSLATED"] = request.getPath();
+	mapped_cgi_env["PATH_TRANSLATED"] = _translated_path;
 	mapped_cgi_env["SCRIPT_NAME"] = request.getPath();
 	if (mapped_cgi_env["REQUEST_METHOD"] == "GET")
 		mapped_cgi_env["QUERY_STRING"] = request.getQueryString();

--- a/classes/Response.cpp
+++ b/classes/Response.cpp
@@ -6,7 +6,7 @@
 /*   By: mbouzaie <mbouzaie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/25 15:09:59 by mbouzaie          #+#    #+#             */
-/*   Updated: 2022/02/18 10:33:27 by acastelb         ###   ########.fr       */
+/*   Updated: 2022/02/22 14:04:13 by acastelb         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -261,7 +261,10 @@ void		Response::prepare(Request &request)
 	else if (endsWith(request.getPath(), ".php"))
 	{
 		std::string s("bin/php-cgi"); // Path to cgi binary
-		Cgi cgi((char *)s.c_str(), request); // Cgi constr.
+		std::string t_path(request.getPath());
+		if (t_path[0] == '/')
+			t_path.erase(0, 1);
+		Cgi cgi((char *)s.c_str(), t_path, request); // Cgi constr.
 		cgi.runCgi(request); // run Cgi
 		char *output = cgi.getOutput(); // get Cgi result, use getStatusCode for status code (int)
 		char *body = strstr(output, "\r\n\r\n"); // get output body

--- a/headers/Cgi.hpp
+++ b/headers/Cgi.hpp
@@ -11,6 +11,7 @@ class Cgi {
 	private:
 
 		std::string _cgi_path;
+		std::string _translated_path;
 		char _output[CGI_BUFFER_SIZE];
 		int _body_pipe[2]; // PARENT -> CHILD, SEND BODY
 		int _output_pipe[2]; // CHILD -> PARENT, SEND CGI OUTPUT
@@ -20,13 +21,15 @@ class Cgi {
 		char **_cgi_env;
 
 	public:
-		Cgi(char *path, Request &request);
+		Cgi(char *cgi_path, std::string t_path, Request &request);
 		Cgi(const Cgi &other);
 		~Cgi();
 		Cgi &operator=(const Cgi &other);
 
 		void runCgi(Request &request);
 		void setCgiPath(char *path);
+		void setTranslatedPath(std::string t_path);
+		std::string getTranslatedPath() const ;
 		std::string getCgiPath() const;
 		char *getOutput() const;
 		int getStatusCode() const;


### PR DESCRIPTION
Add translated_path in Cgi class, it is the real path of requested file, after url path translation. Now it is url path minus first '/' (/tests/www/infos.php -> tests/www/infos.php). It is temporary, while url path translation with config file directives isn't set)